### PR TITLE
Separated executable from build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-EXECUTABLE = "bin/stars"
+EXECUTABLE = stars
+BUILD_DIR = bin
 
 install:
-	echo "Installing Stars as $(SUDO_USER)"
+	@echo "Installing Stars as $(SUDO_USER)"
 	shards build --release
 	rm -rf /usr/local/bin/$(EXECUTABLE)
-	cp $(EXECUTABLE) /usr/local/bin/
+	cp $(BUILD_DIR)/$(EXECUTABLE) /usr/local/bin/
 	crystal spec --fail-fast
-	echo "Successfully installed Stars!"
+	@echo "Successfully installed Stars!"


### PR DESCRIPTION
If the executable is bin/stars,
the rm command will remove /usr/local/bin/bin/stars - which could lead to unwanted behavior in my opinion also silenced the echo commands for prettier output